### PR TITLE
Code coverage tool (Istanbul) added.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+coverage

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">= 0.4.0"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+	    "coverage": "istanbul cover ./node_modules/grunt-contrib-nodeunit/node_modules/nodeunit/bin/nodeunit test"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
@@ -35,7 +36,8 @@
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-jshint": "~0.1",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-watch": "~0.2"
+    "grunt-contrib-watch": "~0.2",
+    "istanbul": "^0.3.2"
   },
   "keywords": ["file", "filesize", "size", "readable", "file system"]
 }


### PR DESCRIPTION
Hello,
As a part of our Node.js course we are studying unit testing and tools for measuring code coverage. So I picked your module and added code coverage tool called Istanbul to your module. See https://www.npmjs.org/package/istanbul

Istanbul creates coverage-folder where the results are placed. In coverage/lcov-report folder you can find index.html which provides visual presentation of the code coverage.

To run code coverage tool: `npm run-script coverage`
