### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/avoidwork/filesize.js/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD-3",
-      "url": "https://raw.github.com/avoidwork/filesize.js/master/LICENSE"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "main": "lib/filesize",
   "engines": {
     "node": ">= 0.4.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/