### PR TITLE
Add bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "filesize",
+  "description": "JavaScript library to generate a human readable String describing the file size",
+  "keywords": ["file", "filesize", "size", "readable", "file system"],
+  "homepage": "http://filesizejs.com",
+  "main": ["./lib/filesize.js"],
+  "ignore": [
+    "test",
+    ".gitignore"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:avoidwork/filesize.js.git"
+  },
+  "authors": [
+    {
+      "name": "Jason Mulligan",
+      "email": "jason.mulligan@avoidwork.com",
+      "homepage": "http://avoidwork.com"
+    }
+  ],
+  "license": "BSD-3-Clause"
+}


### PR DESCRIPTION
I'm adding the bower.json because I need the attribute "main" to specify the entry-point files necessary to use the package. Rails assets pipeline reads this attribute to easily integrate with the app.

More details about bower.json:
https://github.com/bower/spec/blob/master/json.md