### PR TITLE
Add support for localeOptions option: allow customization of i18n output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ _*(array)*_ Array of full form overrides, default is `[]`
 ### locale (overrides 'separator')
 _*(string || boolean)*_ BCP 47 language tag to specify a locale, or `true` to use default locale, default is `""`
 
+### localeOptions (overrides 'separator', requires string for 'locale' option)
+_*(object)*_ Dictionary of options defined by ECMA-402 ([Number.prototype.toLocaleString](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString)). Requires locale option to be explicitly passed as a string, otherwise is ignored.
+
 ### output
 _*(string)*_ Output of function (`array`, `exponent`, `object`, or `string`), default is `string`
 

--- a/lib/filesize.es6.js
+++ b/lib/filesize.es6.js
@@ -33,7 +33,7 @@
 	function filesize (arg, descriptor = {}) {
 		let result = [],
 			val = 0,
-			e, base, bits, ceil, full, fullforms, locale, neg, num, output, round, unix, separator, spacer, standard, symbols;
+			e, base, bits, ceil, full, fullforms, locale, localeOptions, neg, num, output, round, unix, separator, spacer, standard, symbols;
 
 		if (isNaN(arg)) {
 			throw new TypeError("Invalid number");
@@ -44,6 +44,7 @@
 		base = descriptor.base || 2;
 		round = descriptor.round !== void 0 ? descriptor.round : unix ? 1 : 2;
 		locale = descriptor.locale !== void 0 ? descriptor.locale : "";
+		localeOptions = descriptor.localeOptions || {};
 		separator = descriptor.separator !== void 0 ? descriptor.separator : "";
 		spacer = descriptor.spacer !== void 0 ? descriptor.spacer : unix ? "" : " ";
 		symbols = descriptor.symbols || {};
@@ -119,7 +120,7 @@
 		if (locale === true) {
 			result[0] = result[0].toLocaleString();
 		} else if (locale.length > 0) {
-			result[0] = result[0].toLocaleString(locale);
+			result[0] = result[0].toLocaleString(locale, localeOptions);
 		} else if (separator.length > 0) {
 			result[0] = result[0].toString().replace(".", separator);
 		}

--- a/lib/filesize.js
+++ b/lib/filesize.js
@@ -44,6 +44,7 @@
 		    full = void 0,
 		    fullforms = void 0,
 		    locale = void 0,
+		    localeOptions = void 0,
 		    neg = void 0,
 		    num = void 0,
 		    output = void 0,
@@ -63,6 +64,7 @@
 		base = descriptor.base || 2;
 		round = descriptor.round !== void 0 ? descriptor.round : unix ? 1 : 2;
 		locale = descriptor.locale !== void 0 ? descriptor.locale : "";
+		localeOptions = descriptor.localeOptions || {};
 		separator = descriptor.separator !== void 0 ? descriptor.separator : "";
 		spacer = descriptor.spacer !== void 0 ? descriptor.spacer : unix ? "" : " ";
 		symbols = descriptor.symbols || {};
@@ -138,7 +140,7 @@
 		if (locale === true) {
 			result[0] = result[0].toLocaleString();
 		} else if (locale.length > 0) {
-			result[0] = result[0].toLocaleString(locale);
+			result[0] = result[0].toLocaleString(locale, localeOptions);
 		} else if (separator.length > 0) {
 			result[0] = result[0].toString().replace(".", separator);
 		}

--- a/src/filesize.js
+++ b/src/filesize.js
@@ -9,7 +9,7 @@
 	function filesize (arg, descriptor = {}) {
 		let result = [],
 			val = 0,
-			e, base, bits, ceil, full, fullforms, locale, neg, num, output, round, unix, separator, spacer, standard, symbols;
+			e, base, bits, ceil, full, fullforms, locale, localeOptions, neg, num, output, round, unix, separator, spacer, standard, symbols;
 
 		if (isNaN(arg)) {
 			throw new TypeError("Invalid number");
@@ -20,6 +20,7 @@
 		base = descriptor.base || 2;
 		round = descriptor.round !== void 0 ? descriptor.round : unix ? 1 : 2;
 		locale = descriptor.locale !== void 0 ? descriptor.locale : "";
+		localeOptions = descriptor.localeOptions || {};
 		separator = descriptor.separator !== void 0 ? descriptor.separator : "";
 		spacer = descriptor.spacer !== void 0 ? descriptor.spacer : unix ? "" : " ";
 		symbols = descriptor.symbols || {};
@@ -95,7 +96,7 @@
 		if (locale === true) {
 			result[0] = result[0].toLocaleString();
 		} else if (locale.length > 0) {
-			result[0] = result[0].toLocaleString(locale);
+			result[0] = result[0].toLocaleString(locale, localeOptions);
 		} else if (separator.length > 0) {
 			result[0] = result[0].toString().replace(".", separator);
 		}

--- a/test/filesize_test.js
+++ b/test/filesize_test.js
@@ -161,5 +161,19 @@ exports.filesize = {
 		test.equal(filesize(1040, {locale: true}), Number(1.02).toLocaleString() + " KB", "Should be '" + Number(1.02).toLocaleString() + " KB'");
 		test.equal(filesize(1040, {locale: "de"}), Number(1.02).toLocaleString("de") + " KB", "Should be '" + Number(1.02).toLocaleString("de") + " KB'");
 		test.done();
+	},
+	localeOptions: function (test) {
+		test.expect(4);
+		test.equal(filesize(1024, {locale: "de"}), "1 KB", "Should be '1 KB'");
+		test.equal(filesize(1024, {localeOptions: {minimumFractionDigits: 1}}), "1 KB", "Should be '1 KB'");
+		test.equal(filesize(1024, {
+			locale: true,
+			localeOptions: {minimumFractionDigits: 1}
+		}), "1 KB", "Should be '1 KB'");
+		test.equal(filesize(1024, {
+			locale: "de",
+			localeOptions: {minimumFractionDigits: 1}
+		}), Number(1).toLocaleString("de", {minimumFractionDigits: 1}) + " KB", "Should be '" + Number(1).toLocaleString("de", {minimumFractionDigits: 1}) + " KB'");
+		test.done();
 	}
 };


### PR DESCRIPTION
This PR adds support for passing an additional parameter `localeOptions` that is used when an explicit `locale` is passed to allow for further customization of the output. Defaults to `{}`.

This is particularly useful for places where filesize is highly dynamic/animated and there is a desire to enforce a number of fixed digits, even in cases where the decimal would be zero:

Example without (notice the left-shift of the digits when no zero decimal):
![Sep-11-2019 12-23-00](https://user-images.githubusercontent.com/125866/64719995-0de47a80-d48f-11e9-9a7e-f49696928157.gif)

Example with: 
![Sep-11-2019 12-23-18](https://user-images.githubusercontent.com/125866/64719965-fc02d780-d48e-11e9-81b6-2d816606e179.gif)

Usage:
```js
filesize(1024, {
  locale: "en-us",
  localeOptions: { minimumFractionDigits: 1 }
})

// => "1.0 KB"
```

The options are from [ECMA-402](https://www.ecma-international.org/ecma-402/1.0/), and are [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).
