### PR TITLE
Build an ES6 module as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "BSD-3-Clause",
   "browser": "lib/filesize.min.js",
   "main": "lib/filesize.js",
+  "module": "lib/filesize.esm.js",
   "types": "filesize.d.ts",
   "engines": {
     "node": ">= 0.4.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const bannerShort = `/*!
 */`;
 
 const umdOutBase = { format: 'umd', name: 'filesize' };
+const esmOutBase = { format: 'esm', name: 'filesize' };
 
 export default [
   {
@@ -23,6 +24,13 @@ export default [
     output: [
       { ...umdOutBase, file: 'lib/filesize.es6.js', banner: bannerLong },
       { ...umdOutBase, file: 'lib/filesize.es6.min.js', banner: bannerShort, plugins: [ terser() ], sourcemap: true },
+    ]
+  },
+  {
+    input: 'src/filesize.js',
+    output: [
+      { ...esmOutBase, file: 'lib/filesize.esm.js', banner: bannerLong },
+      { ...esmOutBase, file: 'lib/filesize.esm.min.js', banner: bannerShort, plugins: [ terser() ], sourcemap: true },
     ]
   },
   {


### PR DESCRIPTION
This is useful for people who are including filesize.js in their own projects using Rollup or some other bundler which supports ES6 modules.

I opted against transpilation with Babel--the use case for this is either that someone is using a bundler (and hence they can add their own transpilation step) or using it directly in a web browser which supports ES6 modules and hence also supports modern JS. As a consequence, this may be a breaking change (if package consumers are using module-aware bundlers, those bundlers will switch over to the non-transpiled module version by default). If desired, I can change it so that the default module is transpiled as well.