### PR TITLE
Make SI and IEC standards defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ filesize.js provides a simple way to get a human readable file size string from 
 `filesize()` accepts an optional descriptor Object as a second argument, so you can customize the output.
 
 ### base
-_*(number)*_ Number base, default is `2`
+_*(number)*_ Number base, default is `10`
 
 ### bits
 _*(boolean)*_ Enables `bit` sizes, default is `false`
@@ -51,10 +51,10 @@ _*(string)*_ Decimal separator character, default is `.`
 _*(string)*_ Character between the `result` and `symbol`, default is `" "`
 
 ### standard
-_*(string)*_ Standard unit of measure, can be `iec` or `jedec`, default is `jedec`; can be overruled by `base`
+_*(string)*_ Standard unit of measure, can be `iec` or `jedec`, default is `iec`; can be overruled by `base`
 
 ### symbols
-_*(object)*_ Dictionary of SI/JEDEC/IEC symbols to replace for localization, defaults to english if no match is found
+_*(object)*_ Dictionary of SI/IEC/JEDEC symbols to replace for localization, defaults to english if no match is found
 
 ### unix
 _*(boolean)*_ Enables unix style human readable output, e.g `ls -lh`, default is `false`
@@ -63,21 +63,21 @@ _*(boolean)*_ Enables unix style human readable output, e.g `ls -lh`, default is
 
 ```javascript
 filesize(500);                        // "500 B"
-filesize(500, {bits: true});          // "4 Kb"
-filesize(265318, {base: 10});         // "265.32 kB"
-filesize(265318);                     // "259.1 KB"
-filesize(265318, {round: 0});         // "259 KB"
-filesize(265318, {output: "array"});  // [259.1, "KB"]
-filesize(265318, {output: "object"}); // {value: 259.1, symbol: "KB", exponent: 1, unit: "KB"}
+filesize(500, {bits: true});          // "4 kbit"
+filesize(265318, {base: 2});          // "259.1 KiB"
+filesize(265318);                     // "265.32 kB"
+filesize(265318, {round: 0});         // "265 kB"
+filesize(265318, {output: "array"});  // [265.32, "kB"]
+filesize(265318, {output: "object"}); // {value: 265.32, symbol: "kB", exponent: 1, unit: "kB"}
 filesize(1, {symbols: {B: "Б"}});     // "1 Б"
-filesize(1024);                       // "1 KB"
+filesize(1024);                       // "1.02 kB"
 filesize(1024, {exponent: 0});        // "1024 B"
 filesize(1024, {output: "exponent"}); // 1
-filesize(265318, {standard: "iec"});  // "259.1 KiB"
-filesize(265318, {standard: "iec", fullform: true}); // "259.1 kibibytes"
+filesize(265318, {standard: "jedec"});  // "259.1 KB"
+filesize(265318, {base: 2, fullform: true}); // "259.1 kibibytes"
 filesize(12, {fullform: true, fullforms: ["байтов"]});  // "12 байтов"
-filesize(265318, {separator: ","});   // "259,1 KB"
-filesize(265318, {locale: "de"});   // "259,1 KB"
+filesize(265318, {separator: ","});   // "265,32 kB"
+filesize(265318, {locale: "de"});   // "265,32 kB"
 ```
 
 ## Partial Application
@@ -86,9 +86,9 @@ upon execution. This can be used to reduce `Object` creation if you call `filesi
 in lexical scope.
 
 ```javascript
-const size = filesize.partial({standard: "iec"});
+const size = filesize.partial({base: 2, standard: "jedec"});
 
-size(265318); // "259.1 KiB"
+size(265318); // "259.1 KB"
 ```
 
 ## How can I load filesize.js?

--- a/src/filesize.js
+++ b/src/filesize.js
@@ -38,14 +38,14 @@ function filesize (arg, descriptor = {}) {
 	bits = descriptor.bits === true;
 	unix = descriptor.unix === true;
 	pad = descriptor.pad === true;
-	base = descriptor.base || 2;
+	base = descriptor.base || 10;
 	round = descriptor.round !== void 0 ? descriptor.round : unix ? 1 : 2;
 	locale = descriptor.locale !== void 0 ? descriptor.locale : "";
 	localeOptions = descriptor.localeOptions || {};
 	separator = descriptor.separator !== void 0 ? descriptor.separator : "";
 	spacer = descriptor.spacer !== void 0 ? descriptor.spacer : unix ? "" : " ";
 	symbols = descriptor.symbols || {};
-	standard = base === 2 ? descriptor.standard || "jedec" : "jedec";
+	standard = base === 2 ? descriptor.standard || "iec" : "jedec";
 	output = descriptor.output || "string";
 	full = descriptor.fullform === true;
 	fullforms = descriptor.fullforms instanceof Array ? descriptor.fullforms : [];
@@ -110,7 +110,7 @@ function filesize (arg, descriptor = {}) {
 		u = result[1] = base === 10 && e === 1 ? bits ? "kbit" : "kB" : symbol[standard][bits ? "bits" : "bytes"][e];
 
 		if (unix) {
-			result[1] = standard === "jedec" ? result[1].charAt(0) : e > 0 ? result[1].replace(/B$/, "") : result[1];
+			result[1] = result[1].charAt(0);
 
 			if (b.test(result[1])) {
 				result[0] = Math.floor(result[0]);

--- a/test/filesize_test.js
+++ b/test/filesize_test.js
@@ -5,7 +5,7 @@ exports.filesize = {
 	setUp: function (done) {
 		this.kilobit = 500;
 		this.edgecase = 1023;
-		this.kilobyte = 1024;
+		this.kibibyte = 1024;
 		this.petabyte = 1125899906842620;
 		this.neg = -1024;
 		this.byte = 1;
@@ -17,54 +17,54 @@ exports.filesize = {
 	},
 	base2: function (test) {
 		test.expect(48);
-		test.equal(filesize(this.kilobit), "500 B", "Should be '500 B'");
-		test.equal(filesize(this.kilobit, {round: 1}), "500 B", "Should be '500 B'");
-		test.equal(filesize(this.kilobit, {round: 1, spacer: ""}), "500B", "Should be '500B'");
-		test.equal(filesize(this.kilobit, {unix: true}), "500", "Should be '500'");
-		test.equal(filesize(this.kilobit, {round: 1, bits: true}), "3.9 Kbit", "Should be '3.9 Kbit'");
-		test.equal(filesize(this.kilobit, {bits: true}), "3.91 Kbit", "Should be '3.91 Kbit'");
-		test.equal(filesize(this.kilobit, {unix: true, bits: true}), "3.9K", "Should be '3.9K'");
-		test.equal(filesize(this.kilobit, {bits: true, output: "array"})[0], 3.91, "Should be '3.91'");
-		test.equal(filesize(this.kilobit, {bits: true, output: "object"}).value, 3.91, "Should be '3.91'");
-		test.equal(filesize(this.edgecase), "1023 B", "Should be '1023 B'");
-		test.equal(filesize(this.edgecase, {round: 1}), "1023 B", "Should be '1023 B'");
-		test.equal(filesize(this.kilobyte), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(this.kilobyte, {round: 1}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(this.kilobyte, {round: 1, spacer: ""}), "1KB", "Should be '1KB'");
-		test.equal(filesize(this.kilobyte, {unix: true}), "1K", "Should be '1K'");
-		test.equal(filesize(this.kilobyte, {bits: true}), "8 Kbit", "Should be '8 Kbit'");
-		test.equal(filesize(this.kilobyte, {round: 1, bits: true}), "8 Kbit", "Should be '8 Kbit'");
-		test.equal(filesize(this.kilobyte, {unix: true, bits: true}), "8K", "Should be '8K'");
-		test.equal(filesize(this.kilobyte, {exponent: 0}), "1024 B", "Should be '1024 B'");
-		test.equal(filesize(this.kilobyte, {exponent: 0, output: "object"}).unit, "B", "Should be 'B'");
-		test.equal(filesize(this.kilobyte, {output: "exponent"}), 1, "Should be '1'");
-		test.equal(filesize(this.kilobyte, {output: "object"}).unit, "KB", "Should be 'KB'");
-		test.equal(filesize(this.neg), "-1 KB", "Should be '-1 KB'");
-		test.equal(filesize(this.neg, {round: 1}), "-1 KB", "Should be '-1 KB'");
-		test.equal(filesize(this.neg, {round: 1, spacer: ""}), "-1KB", "Should be '-1KB'");
-		test.equal(filesize(this.neg, {unix: true}), "-1K", "Should be '-1K'");
-		test.equal(filesize(this.neg, {bits: true}), "-8 Kbit", "Should be '-8 Kbit'");
-		test.equal(filesize(this.neg, {round: 1, bits: true}), "-8 Kbit", "Should be '-8 Kbit'");
-		test.equal(filesize(this.neg, {unix: true, bits: true}), "-8K", "Should be '-8K'");
-		test.equal(filesize(this.byte), "1 B", "Should be '1 B'");
-		test.equal(filesize(this.byte, {round: 1}), "1 B", "Should be '1 B'");
-		test.equal(filesize(this.byte, {round: 1, spacer: ""}), "1B", "Should be '1B'");
-		test.equal(filesize(this.byte, {unix: true}), "1", "Should be '1'");
-		test.equal(filesize(this.byte, {bits: true}), "8 bit", "Should be '8 bit'");
-		test.equal(filesize(this.byte, {round: 1, bits: true}), "8 bit", "Should be '8 bit'");
-		test.equal(filesize(this.byte, {unix: true, bits: true}), "8", "Should be '8'");
-		test.equal(filesize(this.zero), "0 B", "Should be '0 B'");
-		test.equal(filesize(this.zero, {round: 1}), "0 B", "Should be '0 B'");
-		test.equal(filesize(this.zero, {round: 1, spacer: ""}), "0B", "Should be '0B'");
-		test.equal(filesize(this.zero, {unix: true}), "0", "Should be '0'");
-		test.equal(filesize(this.zero, {bits: true}), "0 bit", "Should be '0 bit'");
-		test.equal(filesize(this.zero, {round: 1, bits: true}), "0 bit", "Should be '0 bit'");
-		test.equal(filesize(this.zero, {unix: true, bits: true}), "0", "Should be '0'");
-		test.equal(filesize(this.huge), "82718061255302770 YB", "Should be '82718061255302770 YB'");
-		test.equal(filesize(this.huge, {bits: true}), "661744490042422100 Ybit", "Should be '661744490042422100 Ybit'");
-		test.equal(filesize(this.small), "0 B", "Should be '0 B'");
-		test.equal(filesize(this.small, {bits: true}), "1 bit", "Should be '1 bit'");
-		test.equal(filesize(this.petabyte), "1 PB", "Should be '1 PB'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec"}), "500 B", "Should be '500 B'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", round: 1}), "500 B", "Should be '500 B'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", round: 1, spacer: ""}), "500B", "Should be '500B'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", unix: true}), "500", "Should be '500'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", round: 1, bits: true}), "3.9 Kibit", "Should be '3.9 Kibit'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", bits: true}), "3.91 Kibit", "Should be '3.91 Kibit'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", unix: true, bits: true}), "3.9K", "Should be '3.9K'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", bits: true, output: "array"})[0], 3.91, "Should be '3.91'");
+		test.equal(filesize(this.kilobit, {base: 2, standard: "iec", bits: true, output: "object"}).value, 3.91, "Should be '3.91'");
+		test.equal(filesize(this.edgecase, {base: 2, standard: "iec"}), "1023 B", "Should be '1023 B'");
+		test.equal(filesize(this.edgecase, {base: 2, standard: "iec", round: 1}), "1023 B", "Should be '1023 B'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec"}), "1 KiB", "Should be '1 KiB'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", round: 1}), "1 KiB", "Should be '1 KiB'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", round: 1, spacer: ""}), "1KiB", "Should be '1KiB'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", unix: true}), "1K", "Should be '1K'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", bits: true}), "8 Kibit", "Should be '8 Kibit'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", round: 1, bits: true}), "8 Kibit", "Should be '8 Kibit'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", unix: true, bits: true}), "8K", "Should be '8K'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", exponent: 0}), "1024 B", "Should be '1024 B'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", exponent: 0, output: "object"}).unit, "B", "Should be 'B'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", output: "exponent"}), 1, "Should be '1'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", output: "object"}).unit, "KiB", "Should be 'KiB'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec"}), "-1 KiB", "Should be '-1 KiB'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", round: 1}), "-1 KiB", "Should be '-1 KiB'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", round: 1, spacer: ""}), "-1KiB", "Should be '-1KiB'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", unix: true}), "-1K", "Should be '-1K'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", bits: true}), "-8 Kibit", "Should be '-8 Kibit'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", round: 1, bits: true}), "-8 Kibit", "Should be '-8 Kibit'");
+		test.equal(filesize(this.neg, {base: 2, standard: "iec", unix: true, bits: true}), "-8K", "Should be '-8K'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec"}), "1 B", "Should be '1 B'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", round: 1}), "1 B", "Should be '1 B'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", round: 1, spacer: ""}), "1B", "Should be '1B'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", unix: true}), "1", "Should be '1'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", bits: true}), "8 bit", "Should be '8 bit'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", round: 1, bits: true}), "8 bit", "Should be '8 bit'");
+		test.equal(filesize(this.byte, {base: 2, standard: "iec", unix: true, bits: true}), "8", "Should be '8'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec"}), "0 B", "Should be '0 B'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", round: 1}), "0 B", "Should be '0 B'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", round: 1, spacer: ""}), "0B", "Should be '0B'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", unix: true}), "0", "Should be '0'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", bits: true}), "0 bit", "Should be '0 bit'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", round: 1, bits: true}), "0 bit", "Should be '0 bit'");
+		test.equal(filesize(this.zero, {base: 2, standard: "iec", unix: true, bits: true}), "0", "Should be '0'");
+		test.equal(filesize(this.huge, {base: 2, standard: "iec"}), "82718061255302770 YiB", "Should be '82718061255302770 YiB'");
+		test.equal(filesize(this.huge, {base: 2, standard: "iec", bits: true}), "661744490042422100 Yibit", "Should be '661744490042422100 Yibit'");
+		test.equal(filesize(this.small, {base: 2, standard: "iec"}), "0 B", "Should be '0 B'");
+		test.equal(filesize(this.small, {base: 2, standard: "iec", bits: true}), "1 bit", "Should be '1 bit'");
+		test.equal(filesize(this.petabyte, {base: 2, standard: "iec"}), "1 PiB", "Should be '1 PiB'");
 		test.done();
 	},
 	base10: function (test) {
@@ -77,13 +77,13 @@ exports.filesize = {
 		test.equal(filesize(this.kilobit, {base: 10, bits: true}), "4 kbit", "Should be '4 kbit'");
 		test.equal(filesize(this.kilobit, {base: 10, round: 1, bits: true}), "4 kbit", "Should be '4 kbit'");
 		test.equal(filesize(this.kilobit, {base: 10, unix: true, bits: true}), "4k", "Should be '4k'");
-		test.equal(filesize(this.kilobyte, {base: 10}), "1.02 kB", "Should be '1.02 kB'");
-		test.equal(filesize(this.kilobyte, {base: 10, round: 1}), "1 kB", "Should be '1 kB'");
-		test.equal(filesize(this.kilobyte, {base: 10, round: 1, spacer: ""}), "1kB", "Should be '1kB'");
-		test.equal(filesize(this.kilobyte, {base: 10, unix: true}), "1k", "Should be '1k'");
-		test.equal(filesize(this.kilobyte, {base: 10, bits: true}), "8.19 kbit", "Should be '8.19 kbit'");
-		test.equal(filesize(this.kilobyte, {base: 10, round: 1, bits: true}), "8.2 kbit", "Should be '8.2 kbit'");
-		test.equal(filesize(this.kilobyte, {base: 10, unix: true, bits: true}), "8.2k", "Should be '8.2k'");
+		test.equal(filesize(this.kibibyte, {base: 10}), "1.02 kB", "Should be '1.02 kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, round: 1}), "1 kB", "Should be '1 kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, round: 1, spacer: ""}), "1kB", "Should be '1kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, unix: true}), "1k", "Should be '1k'");
+		test.equal(filesize(this.kibibyte, {base: 10, bits: true}), "8.19 kbit", "Should be '8.19 kbit'");
+		test.equal(filesize(this.kibibyte, {base: 10, round: 1, bits: true}), "8.2 kbit", "Should be '8.2 kbit'");
+		test.equal(filesize(this.kibibyte, {base: 10, unix: true, bits: true}), "8.2k", "Should be '8.2k'");
 		test.equal(filesize(this.neg, {base: 10}), "-1.02 kB", "Should be '-1.02 kB'");
 		test.equal(filesize(this.neg, {base: 10, round: 1}), "-1 kB", "Should be '-1 kB'");
 		test.equal(filesize(this.neg, {base: 10, round: 1, spacer: ""}), "-1kB", "Should be '-1kB'");
@@ -116,14 +116,14 @@ exports.filesize = {
 	},
 	symbols: function (test) {
 		test.expect(2);
-		test.equal(filesize(this.byte, {symbols: {B: "Б"}}), "1 Б", "Should be '1 Б'");
-		test.equal(filesize(this.kilobyte, {symbols: {B: "Б"}}), "1 KB", "Should be '1 KB'");
+		test.equal(filesize(this.byte, {base: 10, symbols: {B: "Б"}}), "1 Б", "Should be '1 Б'");
+		test.equal(filesize(this.kibibyte, {base: 10, symbols: {B: "Б"}}), "1.02 kB", "Should be '1.02 kB'");
 		test.done();
 	},
 	partial: function (test) {
 		test.expect(1);
-		test.size = filesize.partial({exponent: 0});
-		test.equal(test.size(this.kilobyte), "1024 B", "Should be '1024 B'");
+		test.size = filesize.partial({base: 10, exponent: 0});
+		test.equal(test.size(this.kibibyte), "1024 B", "Should be '1024 B'");
 		test.done();
 	},
 	bits: function (test) {
@@ -135,74 +135,83 @@ exports.filesize = {
 	},
 	fullform: function (test) {
 		test.expect(9);
-		test.equal(filesize(0, {fullform: true}), "0 bytes", "Should be '0 bytes'");
-		test.equal(filesize(0, {fullform: true, output: "object"}).unit, "B", "Should be 'B'");
-		test.equal(filesize(1, {bits: true, base: 10, fullform: true}), "8 bits", "Should be '8 bits'");
+		test.equal(filesize(0, {base: 10, fullform: true}), "0 bytes", "Should be '0 bytes'");
+		test.equal(filesize(0, {base: 10, fullform: true, output: "object"}).unit, "B", "Should be 'B'");
+		test.equal(filesize(1, {base: 10, bits: true, fullform: true}), "8 bits", "Should be '8 bits'");
 		test.equal(filesize(1, {base: 10, fullform: true}), "1 byte", "Should be '1 byte'");
-		test.equal(filesize(this.kilobyte, {fullform: true}), "1 kilobyte", "Should be '1 kilobyte'");
-		test.equal(filesize(this.kilobyte, {fullform: true, standard: "iec"}), "1 kibibyte", "Should be '1 kibibyte'");
-		test.equal(filesize(this.kilobyte, {fullform: true, standard: "iec", output: "object"}).unit, "KiB", "Should be 'KiB'");
-		test.equal(filesize(this.kilobyte * 1.3, {
-			fullform: true,
-			standard: "iec"
+		test.equal(filesize(this.kibibyte, {base: 10, fullform: true}), "1.02 kilobytes", "Should be '1.02 kilobytes'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", fullform: true }), "1 kibibyte", "Should be '1 kibibyte'");
+		test.equal(filesize(this.kibibyte, {base: 2, standard: "iec", fullform: true, output: "object"}).unit, "KiB", "Should be 'KiB'");
+		test.equal(filesize(this.kibibyte * 1.3, {
+			base: 2,
+			standard: "iec",
+			fullform: true
 		}), "1.3 kibibytes", "Should be '1.3 kibibytes'");
-		test.equal(filesize(0, {fullform: true, fullforms: ["байт"]}), "0 байт", "Should be '0 байт'");
+		test.equal(filesize(0, {base: 10, fullform: true, fullforms: ["байт"]}), "0 байт", "Should be '0 байт'");
 		test.done();
 	},
 	exponent: function (test) {
 		test.expect(2);
-		test.equal(filesize(0, {exponent: 0}), "0 B", "Should be '0 B'");
-		test.equal(filesize(0, {exponent: 2}), "0 MB", "Should be '0 MB'");
+		test.equal(filesize(0, {base: 10, exponent: 0}), "0 B", "Should be '0 B'");
+		test.equal(filesize(0, {base: 10, exponent: 2}), "0 MB", "Should be '0 MB'");
 		test.done();
 	},
 	separator: function (test) {
 		test.expect(3);
-		test.equal(filesize(1040, {separator: ""}), "1.02 KB", "Should be '1.02 KB'");
-		test.equal(filesize(1040, {separator: ","}), "1,02 KB", "Should be '1,02 KB'");
-		test.equal(filesize(1040, {separator: ",", round: 1, pad: true}), "1,0 KB", "Should be '1,0 KB'");
+		test.equal(filesize(1040, {base: 10, separator: ""}), "1.04 kB", "Should be '1.04 kB'");
+		test.equal(filesize(1040, {base: 10, separator: ","}), "1,04 kB", "Should be '1,04 kB'");
+		test.equal(filesize(1040, {base: 10, separator: ",", round: 1, pad: true}), "1,0 kB", "Should be '1,0 kB'");
 		test.done();
 	},
 	locale: function (test) {
 		test.expect(3);
-		test.equal(filesize(1040, {locale: ""}), "1.02 KB", "Should be '1.02 KB'");
-		test.equal(filesize(1040, {locale: true}), Number(1.02).toLocaleString() + " KB", "Should be '" + Number(1.02).toLocaleString() + " KB'");
-		test.equal(filesize(1040, {locale: "de"}), Number(1.02).toLocaleString("de") + " KB", "Should be '" + Number(1.02).toLocaleString("de") + " KB'");
+		test.equal(filesize(1040, {base: 10, locale: ""}), "1.04 kB", "Should be '1.04 kB'");
+		test.equal(filesize(1040, {base: 10, locale: true}), Number(1.04).toLocaleString() + " kB", "Should be '" + Number(1.04).toLocaleString() + " kB'");
+		test.equal(filesize(1040, {base: 10, locale: "de"}), Number(1.04).toLocaleString("de") + " kB", "Should be '" + Number(1.04).toLocaleString("de") + " kB'");
 		test.done();
 	},
 	localeOptions: function (test) {
 		test.expect(4);
-		test.equal(filesize(1024, {locale: "de"}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024, {localeOptions: {minimumFractionDigits: 1}}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024, {
+		test.equal(filesize(this.kibibyte, {base: 10, locale: "de"}), Number(1.02).toLocaleString("de") + " kB", "Should be '" + Number(1.02).toLocaleString("de") + " kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, localeOptions: {minimumFractionDigits: 1}}), Number(1.02).toLocaleString(undefined, {minimumFractionDigits: 1}) + " kB", "Should be '" + Number(1.02).toLocaleString(undefined, {minimumFractionDigits: 1}) + " kB'");
+		test.equal(filesize(this.kibibyte, {
+			base: 10,
 			locale: true,
 			localeOptions: {minimumFractionDigits: 1}
-		}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024, {
+		}), Number(1.02).toLocaleString(undefined, {minimumFractionDigits: 1}) + " kB", "Should be '" + Number(1.02).toLocaleString(undefined, {minimumFractionDigits: 1}) + " kB'");
+		test.equal(filesize(this.kibibyte, {
+			base: 10,
 			locale: "de",
 			localeOptions: {minimumFractionDigits: 1}
-		}), Number(1).toLocaleString("de", {minimumFractionDigits: 1}) + " KB", "Should be '" + Number(1).toLocaleString("de", {minimumFractionDigits: 1}) + " KB'");
+		}), Number(1.02).toLocaleString("de", {minimumFractionDigits: 1}) + " kB", "Should be '" + Number(1.02).toLocaleString("de", {minimumFractionDigits: 1}) + " kB'");
 		test.done();
 	},
 	roundingMethod: function (test) {
 		test.expect(9);
-		test.equal(filesize(1024, {roundingMethod: "round"}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024, {roundingMethod: "floor"}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024, {roundingMethod: "ceil"}), "1 KB", "Should be '1 KB'");
-		test.equal(filesize(1024 * 1.333, {roundingMethod: "round"}), "1.33 KB", "Should be '1.33 KB'");
-		test.equal(filesize(1024 * 1.333, {roundingMethod: "floor"}), "1.33 KB", "Should be '1.33 KB'");
-		test.equal(filesize(1024 * 1.333, {roundingMethod: "ceil"}), "1.34 KB", "Should be '1.34 KB'");
-		test.equal(filesize(1024 * 1.666, {round: 1, roundingMethod: "round"}), "1.7 KB", "Should be '1.7 KB'");
-		test.equal(filesize(1024 * 1.666, {round: 1, roundingMethod: "floor"}), "1.6 KB", "Should be '1.6 KB'");
-		test.equal(filesize(1024 * 1.666, {round: 1, roundingMethod: "ceil"}), "1.7 KB", "Should be '1.7 KB'");
+		test.equal(filesize(this.kibibyte, {base: 10, roundingMethod: "round"}), "1.02 kB", "Should be '1.02 kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, roundingMethod: "floor"}), "1.02 kB", "Should be '1.02 kB'");
+		test.equal(filesize(this.kibibyte, {base: 10, roundingMethod: "ceil"}), "1.03 kB", "Should be '1.03 kB'");
+		test.equal(filesize(this.kibibyte * 1.333, {base: 10, roundingMethod: "round"}), "1.36 kB", "Should be '1.36 kB'");
+		test.equal(filesize(this.kibibyte * 1.333, {base: 10, roundingMethod: "floor"}), "1.36 kB", "Should be '1.36 kB'");
+		test.equal(filesize(this.kibibyte * 1.333, {base: 10, roundingMethod: "ceil"}), "1.37 kB", "Should be '1.37 kB'");
+		test.equal(filesize(this.kibibyte * 1.456, {base: 10, round: 1, roundingMethod: "round"}), "1.5 kB", "Should be '1.5 kB'");
+		test.equal(filesize(this.kibibyte * 1.456, {base: 10, round: 1, roundingMethod: "floor"}), "1.4 kB", "Should be '1.4 kB'");
+		test.equal(filesize(this.kibibyte * 1.456, {base: 10, round: 1, roundingMethod: "ceil"}), "1.5 kB", "Should be '1.5 kB'");
 		test.done();
 	},
 	precision: function (test) {
 		test.expect(5);
-		test.equal(filesize(1024 * 1, {precision: 3}), "1.00 KB", "Should be '1.00 KB'");
-		test.equal(filesize(1024 * 1024 * 10.25, {precision: 3}), "10.3 MB", "Should be '10.3 MB'");
-		test.equal(filesize(1024 * 1024 * 10.25, {precision: "x"}), "10.25 MB", "Should be '10.25 MB'");
-		test.equal(filesize(1024 * 1024 * 1024, {precision: 3}), "1.00 GB", "Should be '1.00 GB'");
-		test.equal(filesize(Math.pow(1024, 10), {precision: 3}), "1e+6 YB", "Should be '1e+6 YB'");
+		test.equal(filesize(this.kibibyte * 1, {base: 10, precision: 3}), "1.02 kB", "Should be '1.02 kB'");
+		test.equal(filesize(this.kibibyte * this.kibibyte * 10.25, {base: 10, precision: 3}), "10.8 MB", "Should be '10.8 MB'");
+		test.equal(filesize(this.kibibyte * this.kibibyte * 10.25, {base: 10, precision: "x"}), "10.75 MB", "Should be '10.75 MB'");
+		test.equal(filesize(this.kibibyte * this.kibibyte * this.kibibyte, {base: 10, precision: 3}), "1.07 GB", "Should be '1.07 GB'");
+		test.equal(filesize(Math.pow(this.kibibyte, 10), {base: 10, precision: 3}), "1e+6 YB", "Should be '1e+6 YB'");
+		test.done();
+	},
+	defaults: function (test) {
+		test.expect(2);
+		test.equal(filesize(this.kibibyte), "1.02 kB", "Should be '1.02 kB'");
+		test.equal(filesize(this.kibibyte, {base: 2}), "1 KiB", "Should be '1 KiB'");
 		test.done();
 	}
 };


### PR DESCRIPTION
This commit makes the SI standard (base 10) the generic default, and the
IEC standard the default for base-2 formatting in order to make it as
intuitive as possible, to reduce any ambiguity, and to mirror the
industry standard.

Fixes #137