### PR TITLE
feat: infer result type correctly with TypeScript

### DIFF
--- a/filesize.d.ts
+++ b/filesize.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for filesize 6.0.1
+// Type definitions for filesize 8.0.3
 // Project: https://github.com/avoidwork/filesize.js, https://filesizejs.com
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Renaud Chaput <https://github.com/renchap>
 //                 Roman Nuritdinov <https://github.com/Ky6uk>
 //                 Sam Hulick <https://github.com/ffxsam>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+//                 Tomoto S. Washio <https://github.com/tomoto>
 
 declare var fileSize: Filesize.Filesize;
 export = fileSize;
@@ -100,8 +100,24 @@ declare namespace Filesize {
         roundingMethod?: "round" | "floor" | "ceil";
     }
 
+    // Result type inference from the output option
+    interface ResultTypeMap {
+        array: [number, string];
+        exponent: number;
+        object: {
+            value: number,
+            symbol: string,
+            exponent: number,
+            unit: string,
+        };
+        string: string;
+    }
+    type DefaultOutput<O extends Options> = Exclude<O["output"], keyof ResultTypeMap> extends never ? never : "string"
+    type CanonicalOutput<O extends Options> = Extract<O["output"], keyof ResultTypeMap> | DefaultOutput<O>
+
     interface Filesize {
-        (bytes: number, options?: Options): string;
-        partial: (options: Options) => ((bytes: number) => string);
+        (bytes: number): string;
+        <O extends Options>(bytes: number, options: O): ResultTypeMap[CanonicalOutput<O>];
+        partial: <O extends Options>(options: O) => ((bytes: number) => ResultTypeMap[CanonicalOutput<O>]);
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "changelog": "auto-changelog -p",
-    "test": "npm run build && npm run lint && npm run test:unit",
+    "test": "npm run build && npm run lint && npm run test:unit && npm run test:type",
     "test:unit": "nodeunit test/*.js",
-    "lint": "eslint test/*.js src/*.js",
-    "types": "npx typescript src/filesize.js --declaration --allowJs --emitDeclarationOnly --outDir ./"
+    "test:type": "npx tsc -p test",
+    "lint": "eslint test/*.js src/*.js"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+        "noImplicitAny": true,
+    },
+    "include": [
+        "*.ts"
+    ]
+}

--- a/test/typeinference_test.ts
+++ b/test/typeinference_test.ts
@@ -1,0 +1,60 @@
+// This "test" is to validate the type inference, i.e. only to compile, but not to run.
+
+import filesize from "../filesize";
+
+//
+// check functions for compilation time, no need to implement
+//
+
+function shouldBeString(x: string) {}
+function shouldBeNumberUnitPair(x: [number, string]) {}
+function shouldBeNumber(x: number) {}
+
+type FilesizeObject = {
+    value: number,
+    symbol: string,
+    exponent: number,
+    unit: string,
+}
+function shouldBeObject(x: FilesizeObject) {}
+
+//
+// single possibility (typical)
+//
+
+// direct call
+shouldBeString(filesize(123));
+shouldBeString(filesize(123, {}));
+shouldBeString(filesize(123, { output: undefined }));
+shouldBeString(filesize(123, { output: "string" }));
+shouldBeNumberUnitPair(filesize(123, { output: "array" }));
+shouldBeNumber(filesize(123, { output: "exponent" }));
+shouldBeObject(filesize(123, { output: "object" }));
+
+// partial
+shouldBeString(filesize.partial({})(123))
+shouldBeString(filesize.partial({ output: "string" })(123))
+shouldBeNumberUnitPair(filesize.partial({ output: "array" })(123))
+shouldBeNumber(filesize.partial({ output: "exponent" })(123))
+shouldBeObject(filesize.partial({ output: "object" })(123))
+
+//
+// mutliple possibilities (tricky)
+//
+
+let opt1!: { output: "string" | "array" };
+const result1 = filesize(123, opt1); // string | [number, string]
+result1 as string
+result1 as [number, string];
+
+let opt2!: { output: "exponent" | "object" };
+const result2 = filesize(123, opt2); // number | { ... }
+result2 as number
+result2 as FilesizeObject
+
+// Note: strictNullChecks needs to be true to correctly handle this scenario.
+// If false, the compiler cannot know the return type may be string.
+let opt3!: { output?: "exponent" };
+const result3 = filesize(123, opt3); // string | number
+result3 as number
+result3 as string


### PR DESCRIPTION
Greetings, it looks like some people (#126 for example) want the type definition to support the non-string results, and here is my contribution.

Basically I added the minimal fix to the type definition to infer the result type based on the output option, and the TypeScript test cases to validate the type checks successfully pass as intended. As long as the output option is statically known to the compiler (which hopefully would be the case in the typical use cases), the result type can be uniquely determined; otherwise, the applications are still responsible for asserting the expected type but they no longer need to insert the dirty `as unknown` at least.

I also removed the mention to DefinitelyTyped in the doc comment and the type definition generaiton script in package.json since they looked obsolete.

Hope this helps. Thank you very much.