### PR TITLE
Fixing type comments of `base` and `standard`

### DIFF
--- a/filesize.d.ts
+++ b/filesize.d.ts
@@ -39,7 +39,7 @@ declare namespace Filesize {
 
     interface Options {
         /**
-         * Number base, default is 2
+         * Number base, default is 10
          */
         base?: number;
         /**
@@ -83,7 +83,7 @@ declare namespace Filesize {
          */
         spacer?: string;
         /**
-         * Standard unit of measure, can be iec or jedec, default is jedec; can be overruled by base
+         * Standard unit of measure, can be iec or jedec, default is iec; can be overruled by base
          */
         standard?: "iec" | "jedec";
         /**


### PR DESCRIPTION
Fixing the type descriptions for the newly changed default options:

![image](https://user-images.githubusercontent.com/6101654/138814260-4e881754-7e35-44e4-97fe-f0946237a105.png)

![image](https://user-images.githubusercontent.com/6101654/138814411-9cd5a9d8-7720-49ab-be2c-a12b133d1c87.png)
