### PR TITLE
feat: infer result type correctly with TypeScript (no "npx tsc")

### DIFF
--- a/filesize.d.ts
+++ b/filesize.d.ts
@@ -1,10 +1,10 @@
-// Type definitions for filesize 6.0.1
+// Type definitions for filesize 8.0.3
 // Project: https://github.com/avoidwork/filesize.js, https://filesizejs.com
 // Definitions by: Giedrius Grabauskas <https://github.com/GiedriusGrabauskas>
 //                 Renaud Chaput <https://github.com/renchap>
 //                 Roman Nuritdinov <https://github.com/Ky6uk>
 //                 Sam Hulick <https://github.com/ffxsam>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+//                 Tomoto S. Washio <https://github.com/tomoto>
 
 declare var fileSize: Filesize.Filesize;
 export = fileSize;
@@ -100,8 +100,24 @@ declare namespace Filesize {
         roundingMethod?: "round" | "floor" | "ceil";
     }
 
+    // Result type inference from the output option
+    interface ResultTypeMap {
+        array: [number, string];
+        exponent: number;
+        object: {
+            value: number,
+            symbol: string,
+            exponent: number,
+            unit: string,
+        };
+        string: string;
+    }
+    type DefaultOutput<O extends Options> = Exclude<O["output"], keyof ResultTypeMap> extends never ? never : "string"
+    type CanonicalOutput<O extends Options> = Extract<O["output"], keyof ResultTypeMap> | DefaultOutput<O>
+
     interface Filesize {
-        (bytes: number, options?: Options): string;
-        partial: (options: Options) => ((bytes: number) => string);
+        (bytes: number): string;
+        <O extends Options>(bytes: number, options: O): ResultTypeMap[CanonicalOutput<O>];
+        partial: <O extends Options>(options: O) => ((bytes: number) => ResultTypeMap[CanonicalOutput<O>]);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "nodeunit-x": "^0.14.0",
         "rollup": "^2.56.3",
         "rollup-plugin-babel": "^4.4.0",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup-plugin-terser": "^7.0.2",
+        "typescript": "^3.9.0"
       },
       "engines": {
         "node": ">= 0.4.0"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "changelog": "auto-changelog -p",
-    "test": "npm run build && npm run lint && npm run test:unit",
+    "test": "npm run build && npm run lint && npm run test:unit && npm run test:type",
     "test:unit": "nodeunit test/*.js",
-    "lint": "eslint test/*.js src/*.js",
-    "types": "npx typescript src/filesize.js --declaration --allowJs --emitDeclarationOnly --outDir ./"
+    "test:type": "tsc -p test",
+    "lint": "eslint test/*.js src/*.js"
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",
@@ -40,7 +40,8 @@
     "nodeunit-x": "^0.14.0",
     "rollup": "^2.56.3",
     "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^3.9.0"
   },
   "keywords": [
     "file",

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "noEmit": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+        "noImplicitAny": true,
+    },
+    "include": [
+        "*.ts"
+    ]
+}

--- a/test/typeinference_test.ts
+++ b/test/typeinference_test.ts
@@ -1,0 +1,60 @@
+// This "test" is to validate the type inference, i.e. only to compile, but not to run.
+
+import filesize from "../filesize";
+
+//
+// check functions for compilation time, no need to implement
+//
+
+function shouldBeString(x: string) {}
+function shouldBeNumberUnitPair(x: [number, string]) {}
+function shouldBeNumber(x: number) {}
+
+type FilesizeObject = {
+    value: number,
+    symbol: string,
+    exponent: number,
+    unit: string,
+}
+function shouldBeObject(x: FilesizeObject) {}
+
+//
+// single possibility (typical)
+//
+
+// direct call
+shouldBeString(filesize(123));
+shouldBeString(filesize(123, {}));
+shouldBeString(filesize(123, { output: undefined }));
+shouldBeString(filesize(123, { output: "string" }));
+shouldBeNumberUnitPair(filesize(123, { output: "array" }));
+shouldBeNumber(filesize(123, { output: "exponent" }));
+shouldBeObject(filesize(123, { output: "object" }));
+
+// partial
+shouldBeString(filesize.partial({})(123))
+shouldBeString(filesize.partial({ output: "string" })(123))
+shouldBeNumberUnitPair(filesize.partial({ output: "array" })(123))
+shouldBeNumber(filesize.partial({ output: "exponent" })(123))
+shouldBeObject(filesize.partial({ output: "object" })(123))
+
+//
+// mutliple possibilities (tricky)
+//
+
+let opt1!: { output: "string" | "array" };
+const result1 = filesize(123, opt1); // string | [number, string]
+result1 as string
+result1 as [number, string];
+
+let opt2!: { output: "exponent" | "object" };
+const result2 = filesize(123, opt2); // number | { ... }
+result2 as number
+result2 as FilesizeObject
+
+// Note: strictNullChecks needs to be true to correctly handle this scenario.
+// If false, the compiler cannot know the return type may be string.
+let opt3!: { output?: "exponent" };
+const result3 = filesize(123, opt3); // string | number
+result3 as number
+result3 as string


### PR DESCRIPTION
Hello, thank you for looking at my previous PR #142 and my apologies that I was not aware "npx tsc" had an issue (as pointed out in https://github.com/avoidwork/filesize.js/pull/142#issuecomment-950324141 ). I am posting a new PR without "npx tsc".

This PR is exactly the same as my previous PR except:
- Use just "tsc" instead of "npx tsc"
- Add dependency to `typescript` (Note, this is only for formality but has no actual impact because `typescript` was already included from another npm module implicitly. Run `npm why typescript` and see what it shows if you are interested.)

I believe now `npm test` should pass as expected. I appreciate your effort. Thank you very much.