### PR TITLE
Fix type inference for output: 'array' when precision is configured

### DIFF
--- a/filesize.d.ts
+++ b/filesize.d.ts
@@ -109,8 +109,8 @@ declare namespace Filesize {
     }
 
     // Result type inference from the output option
-    interface ResultTypeMap {
-        array: [number, string];
+    interface ResultTypeMap<O> {
+        array: [O extends {precision: number} ? string : number, string];
         exponent: number;
         object: {
             value: number,
@@ -120,12 +120,12 @@ declare namespace Filesize {
         };
         string: string;
     }
-    type DefaultOutput<O extends Options> = Exclude<O["output"], keyof ResultTypeMap> extends never ? never : "string"
-    type CanonicalOutput<O extends Options> = Extract<O["output"], keyof ResultTypeMap> | DefaultOutput<O>
+    type DefaultOutput<O extends Options> = Exclude<O["output"], keyof ResultTypeMap<O>> extends never ? never : "string"
+    type CanonicalOutput<O extends Options> = Extract<O["output"], keyof ResultTypeMap<O>> | DefaultOutput<O>
 
     interface Filesize {
         (bytes: number): string;
-        <O extends Options>(bytes: number, options: O): ResultTypeMap[CanonicalOutput<O>];
-        partial: <O extends Options>(options: O) => ((bytes: number) => ResultTypeMap[CanonicalOutput<O>]);
+        <O extends Options>(bytes: number, options: O): ResultTypeMap<O>[CanonicalOutput<O>];
+        partial: <O extends Options>(options: O) => ((bytes: number) => ResultTypeMap<O>[CanonicalOutput<O>]);
     }
 }

--- a/test/typeinference_test.ts
+++ b/test/typeinference_test.ts
@@ -8,6 +8,7 @@ import filesize from "../filesize";
 
 function shouldBeString(x: string) {}
 function shouldBeNumberUnitPair(x: [number, string]) {}
+function shouldBeStringUnitPair(x: [string, string]) {}
 function shouldBeNumber(x: number) {}
 
 type FilesizeObject = {
@@ -28,6 +29,7 @@ shouldBeString(filesize(123, {}));
 shouldBeString(filesize(123, { output: undefined }));
 shouldBeString(filesize(123, { output: "string" }));
 shouldBeNumberUnitPair(filesize(123, { output: "array" }));
+shouldBeStringUnitPair(filesize(123, { precision: 2, output: "array" }));
 shouldBeNumber(filesize(123, { output: "exponent" }));
 shouldBeObject(filesize(123, { output: "object" }));
 


### PR DESCRIPTION
Return type incorrectly typed as `[number, string]`, which is normally
true for `output: 'array'`, but it's actually `[string, string]` if
`precision` is configured