### PR TITLE
fixup: Add interface for filesize options object

### DIFF
--- a/types/filesize.d.ts
+++ b/types/filesize.d.ts
@@ -1,4 +1,4 @@
-export function filesize(arg: any, { bits, pad, base, round, locale, localeOptions, separator, spacer, symbols, standard, output, fullform, fullforms, exponent, roundingMethod, precision }?: {
+export interface FileSizeOptions {
     bits?: boolean;
     pad?: boolean;
     base?: number;
@@ -8,37 +8,23 @@ export function filesize(arg: any, { bits, pad, base, round, locale, localeOptio
     separator?: string;
     spacer?: string;
     symbols?: {};
-    standard?: string;
-    output?: string;
+    standard?: 'iec' | 'jedec';
+    output?: 'array' | 'exponent' | 'object' | 'string';
     fullform?: boolean;
     fullforms?: any[];
     exponent?: number;
-    roundingMethod?: string;
+    roundingMethod?: 'round' | 'floor' | 'ceil';
     precision?: number;
-}): string | number | any[] | {
+}
+
+export function filesize(arg: any, { bits, pad, base, round, locale, localeOptions, separator, spacer, symbols, standard, output, fullform, fullforms, exponent, roundingMethod, precision }?: FileSizeOptions): string | number | any[] | {
     value: any;
     symbol: any;
     exponent: number;
     unit: string;
 };
-export function partial({ bits, pad, base, round, locale, localeOptions, separator, spacer, symbols, standard, output, fullform, fullforms, exponent, roundingMethod, precision }?: {
-    bits?: boolean;
-    pad?: boolean;
-    base?: number;
-    round?: number;
-    locale?: string;
-    localeOptions?: {};
-    separator?: string;
-    spacer?: string;
-    symbols?: {};
-    standard?: string;
-    output?: string;
-    fullform?: boolean;
-    fullforms?: any[];
-    exponent?: number;
-    roundingMethod?: string;
-    precision?: number;
-}): (arg: any) => string | number | any[] | {
+
+export function partial({ bits, pad, base, round, locale, localeOptions, separator, spacer, symbols, standard, output, fullform, fullforms, exponent, roundingMethod, precision }?: FileSizeOptions): (arg: any) => string | number | any[] | {
     value: any;
     symbol: any;
     exponent: number;


### PR DESCRIPTION
This will provide consistency between filesize and partial function options. 

This will also fix an issue I had while utilising the library where I want to validate the options supplied to a generic formatter function for example here is my implementation.

```typescript
interface SomeNumberOptions = {
   compact: bool
}

const getFormatter = (type: string): (value: any, options: SomeNumberOptions | FileSizeOptions) => string {
    const formatters = {
         number: (value: number, options: SomeNumberOptions): string => {...}
         bytes: (value: number, options: FileSizeOptions): string => {...}
    }
    
    return formatters[type]
}
```

I've also updated some options from strings to unions.