### PR TITLE
Rework types to allow Parameters<typeof filesize> to function properly

### DIFF
--- a/types/filesize.d.ts
+++ b/types/filesize.d.ts
@@ -41,14 +41,16 @@ interface FileSizeReturnObject {
 
 type FileSizeReturnArray = [ number, string ]
 
-export function filesize(byteCount: number, options: FileSizeOptionsString | FileSizeOptionsBase): string
-export function filesize(byteCount: number, options: FileSizeOptionsArray): FileSizeReturnArray
-export function filesize(byteCount: number, options: FileSizeOptionsExponent): number
-export function filesize(byteCount: number, options: FileSizeOptionsObject): FileSizeReturnObject
-export function filesize(byteCount: number): string
+type FileSizeOptionStringOrBase = FileSizeOptionsString | FileSizeOptionsBase;
+type FileSizeOptions = FileSizeOptionsArray | FileSizeOptionsExponent | FileSizeOptionsObject | FileSizeOptionStringOrBase | undefined
+type FileSizeReturnType<Options extends FileSizeOptions> =
+    Options extends FileSizeOptionsArray
+        ? FileSizeReturnArray
+        : Options extends FileSizeOptionsExponent
+        ? number
+        : Options extends FileSizeOptionsObject
+        ? FileSizeReturnObject
+        : string;
 
-export function partial(options: FileSizeOptionsString | FileSizeOptionsBase): (byteCount: number) => string
-export function partial(options: FileSizeOptionsArray): (byteCount: number) => FileSizeReturnArray
-export function partial(options: FileSizeOptionsExponent): (byteCount: number) => number
-export function partial(options: FileSizeOptionsObject): (byteCount: number) => FileSizeReturnObject
-export function partial(): (byteCount: number) => string
+export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number, options?: Options): FileSizeReturnType<Options> 
+export function partial<Options extends FileSizeOptions = undefined>(byteCount: number, options?: Options): FileSizeReturnType<Options> 

--- a/types/filesize.d.ts
+++ b/types/filesize.d.ts
@@ -53,4 +53,4 @@ type FileSizeReturnType<Options extends FileSizeOptions> =
         : string;
 
 export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number, options?: Options): FileSizeReturnType<Options> 
-export function partial<Options extends FileSizeOptions = undefined>(byteCount: number, options?: Options): FileSizeReturnType<Options> 
+export function partial<Options extends FileSizeOptions = undefined>(options?: Options): (byteCount: number) => FileSizeReturnType<Options> 


### PR DESCRIPTION
I have a usage in a codebase that relies on the types of the parameters. Initially our code looked something like:

```typescript
type Foo = Parameters<typeof filesize>[1];
```

However since this change (https://github.com/avoidwork/filesize.js/pull/172) change that is no longer possible. There is a [larger thread](https://github.com/microsoft/TypeScript/issues/32164#issuecomment-506810756) in the typescript repo about this.

This PR reworks the types so that they are automatically inferred by the type of `options` passed and avoids overloads.

An alternative to this would be export all the possible option types and return types, but you can get the same result using `Parameters` and `ReturnType` utility types.

TypeScript [Playground Link](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgGLADYQMrAF4QDyADmMAPYgDOAQnFSgN4BQybyARvRAPwBcyAIwAGZAB9kAJgDcrdh2Bgq-TuXJY4IWe2QQAHsUoRwKkAFcAth2jb2MMxgwxyUCyo5qNWuW3uPnrsoCVGBQoADmANoAurZsGOQIcFgqIWEg4eKq6hCaccgJSVgkZJRByACS4BgAdAAicJAAKsAWEKguFo0lFNT5xHAAJu6eud46xFAQCMBUvaaW1lD5UORmIMMC5lY2Psir64MRALIQYAAW5JvIAOQHGzdZNzAJLo8SN0iYN-kMA1CNFypUIRX4DJBQYHpcK-MCaQZwKDXG5zd63YDTNE3ABWEEGmN+AE8rOpyowAL6ycnMZigSCwRAodBYXAEHplACCUABhN0ekgGyoaEwOHwRFIvVo3GQLB0azAxDMYAEN0RPJuzGptPA0HgSGFLLF7OoAFEDEZwHyBYMhczRWyJWU6AwZXt5Yrlbd9IYQMYwBqtXTdYyDfbxaVqIQOLiEGArcYbaHWeHJc6mG6lR6VeRo9N-ZqaUGGfq7cnjVRsCCMvHBUmjY7qGnXXLM0qVWkIgHCzri0yRcmAEpnMxQEBRmNx2XsABuyTMEGCVfCABo9lRiR4MIvoaudN6LZ7tktd+x1optxFV1qwITiH3DQQh2ARyAuTzkABeZCRZBH6DL5AO2raIaRvO86wdCNK2hQgoCbL9S3rCMKyXLJEMg1NuFkMD7zDctPwglNOW5OBeQkdCiNNc1fUtcj+yQyVxzzND6IwyhoIiWCmwkQ4IBgUA8WYHDCKfF8mlvCAAB58P0a1bVYyiqAAPk-PYZP5BN5IfRS31IvYdB4ETh1HXTCX09gBHUuTCPLM0fT9cy2EMv8oEc5BLIbIVZM0mzPKY2M3MMijRNHfywDci8MlkZh8QQDBERQewQFjXpkH4rA5gIaTPJrRMKPwr9eP431BiUgAKDhCUgABhNZwC2RZ-2QchPJUcsAEoBGC4yQHEu9suQlSYumeKpjS9YUsoZB-jIZIBslXKtLwnLCo2PiBNKiqqogWr1kPRqoAAlrkLazzOqM59Rz6qTyyG5gEDKON8XgBwwBCkACPSiBMogMqREkAAWdrZAe6g4zVUj3s+kUfr+4RAYAxhmtbT0ACIIcJVHyWB+7Hr5ezwChr8vth-6AcR5GFTbZBUf3GiwCxnHQZCQClyJtKYbFOGEZlSmsxpoDwkZkG8ZzCd2ZJrmyYp91qdRsW82FmlcbB5BnrgV73oABURWaMAImbgGSbmgZF1WMe13Wjf1r9DeN6XedltGMaV5m4zpv1LagPWDat+34fJx2UYEWnqL9V28cFr2fdtv2MBNmXg4FpcI9VhXY2j63fe962E6Dqm0fThnsekIA)