### PR TITLE
fix: input type should accept string

### DIFF
--- a/types/filesize.d.ts
+++ b/types/filesize.d.ts
@@ -52,5 +52,5 @@ type FileSizeReturnType<Options extends FileSizeOptions> =
         ? FileSizeReturnObject
         : string;
 
-export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number, options?: Options): FileSizeReturnType<Options> 
+export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number | string, options?: Options): FileSizeReturnType<Options> 
 export function partial<Options extends FileSizeOptions = undefined>(options?: Options): (byteCount: number) => FileSizeReturnType<Options> 


### PR DESCRIPTION
> filesize.js provides a simple way to get a human-readable file size string from a number (float or integer) or string

string should be an acceptable input