### PR TITLE
fix: add bigint in filesize.d.ts

### DIFF
--- a/types/filesize.d.ts
+++ b/types/filesize.d.ts
@@ -52,5 +52,5 @@ type FileSizeReturnType<Options extends FileSizeOptions> =
         ? FileSizeReturnObject
         : string;
 
-export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number | string, options?: Options): FileSizeReturnType<Options> 
+export function filesize<Options extends FileSizeOptions = undefined>(byteCount: number | string | bigint, options?: Options): FileSizeReturnType<Options> 
 export function partial<Options extends FileSizeOptions = undefined>(options?: Options): (byteCount: number) => FileSizeReturnType<Options> 


### PR DESCRIPTION
hello 

I am using TS and show it is missing bigint as type  in bytecount argument.

I tried locally and works fine with TS

regardsss 🤙