### PR TITLE
docs: add PR template convention to AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+<!-- Brief description of the changes -->
+
+## Type of Change
+<!-- Mark one with an "x" -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature / enhancement
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Build / dependency / tooling change
+- [ ] Test additions or updates
+- [ ] Other
+
+## Related Issues
+<!-- Reference related issues (format: fixes #123, closes #456, or refs #456) -->
+
+## Testing
+<!-- Describe the tests you ran and how to reproduce them -->
+
+## Checklist
+<!-- Mark each with an "x" -->
+- [ ] `npm test` passes
+- [ ] `npm run build` succeeds
+- [ ] 100% test coverage maintained
+- [ ] No hardcoded secrets or credentials introduced
+- [ ] Zero external dependencies added
+- [ ] ES Modules only (no CommonJS in src/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,10 @@ When auditing or modifying AGENTS.md (or any file):
 3. Push the feature branch and open a PR with `gh pr create --base master`.
 4. Never commit or push directly to `main` or `master`.
 
+### 7.4 Pull Request Templates
+
+If a `.github/PULL_REQUEST_TEMPLATE.md` file exists, it MUST be used when creating PRs. Fill out every section — do not leave any section blank. If a section does not apply, write `N/A` rather than skipping it.
+
 ---
 
 ## 8. Operational Rules


### PR DESCRIPTION
## Summary
- Adds `.github/PULL_REQUEST_TEMPLATE.md` for structured PR descriptions
- Documents the template convention in `AGENTS.md` section 7.4

## Files Changed
- `.github/PULL_REQUEST_TEMPLATE.md` — New PR template (Type of Change, Related Issues, Testing, Checklist)
- `AGENTS.md` — Section 7.4: Pull Request Templates convention

## Checklist
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] No hardcoded secrets or credentials introduced
- [x] Zero external dependencies added