### PR TITLE
fix: clamp negative forced exponent instead of returning NaN

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -289,6 +289,11 @@ export function calculateExponent(num, e, exponent, isDecimal, precision) {
 		if (e < 0) {
 			e = 0;
 		}
+	} else if (e < 0) {
+		// A forced exponent below the auto sentinel (-1) has no meaning and
+		// would otherwise index the power-of-ten/two lookup tables out of
+		// bounds (producing NaN). Clamp to 0, mirroring the e > 8 clamp below.
+		e = 0;
 	}
 
 	if (e > 8) {

--- a/tests/unit/filesize.test.js
+++ b/tests/unit/filesize.test.js
@@ -615,6 +615,23 @@ describe("filesize", () => {
 			const result = filesize(1024, { exponent: NaN, standard: "iec" });
 			assert.strictEqual(result, "1 KiB");
 		});
+
+		it("should clamp an out-of-range negative exponent to 0 instead of returning NaN", () => {
+			// Only -1 is the documented "auto" sentinel. Any other negative exponent
+			// indexed the power lookup tables out of bounds and produced "NaN undefined".
+			assert.strictEqual(filesize(1024, { exponent: -2 }), "1024 B");
+			assert.strictEqual(filesize(1024, { exponent: -100 }), "1024 B");
+		});
+
+		it("should clamp a negative exponent to 0 for object output", () => {
+			const result = filesize(1024, { exponent: -3, output: "object" });
+			assert.deepStrictEqual(result, { value: 1024, symbol: "B", exponent: 0, unit: "B" });
+		});
+
+		it("should clamp a negative exponent to 0 for array output", () => {
+			const result = filesize(1024, { exponent: -3, output: "array" });
+			assert.deepStrictEqual(result, [1024, "B"]);
+		});
 	});
 
 	describe("Error handling", () => {


### PR DESCRIPTION
calculateExponent clamps `e > 8` down to 8, but nothing clamps the other side — any forced `exponent` below `-1` (the documented auto sentinel) sails past both checks and ends up indexing `DECIMAL_POWERS`/`BINARY_POWERS` out of bounds. `filesize(1024, {exponent: -3})` currently returns `"NaN undefined"`, and with `output: "object"` it silently drops `symbol`/`unit` from the result (`{value: NaN, exponent: -3, symbol: undefined, unit: undefined}`), which breaks the documented shape.

Fix just clamps `e < 0` to `0` in the same spot, mirroring the existing `e > 8` clamp. Added tests for the string, object, and array output shapes with a couple of out-of-range values (`-2`, `-3`, `-100`).