### PR TITLE
fix: return the final exponent from output "exponent"

### DIFF
--- a/src/filesize.js
+++ b/src/filesize.js
@@ -126,10 +126,6 @@ export function filesize(
 	e = calculatedE;
 	const autoExponent = exponent === -1 || isNaN(exponent);
 
-	if (output === EXPONENT) {
-		return e;
-	}
-
 	const { result: valueResult, e: valueExponent } = calculateOptimizedValue(
 		num,
 		e,
@@ -162,6 +158,13 @@ export function filesize(
 		);
 		result[0] = precisionResult.value;
 		e = precisionResult.e;
+	}
+
+	// Return the exponent only after every adjustment that other output
+	// modes apply (bits auto-increment, rounding overflow, precision), so
+	// it always matches the exponent reported by object output.
+	if (output === EXPONENT) {
+		return e;
 	}
 
 	u = resolveSymbol(actualStandard, bits, e, isDecimal);

--- a/tests/unit/filesize.test.js
+++ b/tests/unit/filesize.test.js
@@ -128,6 +128,26 @@ describe("filesize", () => {
 			assert.strictEqual(typeof result, "number");
 			assert.strictEqual(result, 1);
 		});
+
+		it("should match the object exponent when rounding overflows the unit", () => {
+			// 999999 renders as "1 MB", so the exponent is 2, not 1
+			assert.strictEqual(filesize(999999, { output: "exponent" }), 2);
+			assert.strictEqual(
+				filesize(999999, { output: "exponent" }),
+				filesize(999999, { output: "object" }).exponent,
+			);
+			// IEC: 1048575 renders as "1 MiB"
+			assert.strictEqual(filesize(1048575, { standard: "iec", output: "exponent" }), 2);
+		});
+
+		it("should match the object exponent when bits auto-increment the unit", () => {
+			// 125000 bytes = 1 Mbit, so the exponent is 2, not 1
+			assert.strictEqual(filesize(125000, { bits: true, output: "exponent" }), 2);
+			assert.strictEqual(
+				filesize(125000, { bits: true, output: "exponent" }),
+				filesize(125000, { bits: true, output: "object" }).exponent,
+			);
+		});
 	});
 
 	describe("Rounding", () => {


### PR DESCRIPTION
The `output: "exponent"` early return fires before the bits auto-increment, rounding-overflow, and precision adjustments that can bump the exponent, so it can disagree with every other output mode:

```js
filesize(999999)                                  // '1 MB'
filesize(999999, {output: 'object'}).exponent     // 2
filesize(999999, {output: 'exponent'})            // 1  ← inconsistent
```

Feeding the result back as a forced exponent then produces `'1000 kB'`. In bits mode the disagreement covers whole ranges — every value in `[125000, 999999]` returns `1` while rendering as `Mbit` (exponent 2). Same for IEC at `1048575`.

This moves the early return after those adjustments so the reported exponent always matches the exponent used to render the value. `filesize(0, {output: 'exponent'})` and forced-exponent behavior are unchanged; adds regression tests for the rounding-overflow and bits cases.