### PR TITLE
fix: honor the pad option for zero values

### DIFF
--- a/src/filesize.js
+++ b/src/filesize.js
@@ -112,6 +112,8 @@ export function filesize(
 			fullforms,
 			output,
 			spacer,
+			pad,
+			round,
 		);
 	}
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -62,6 +62,8 @@ export function getBaseConfiguration(standard, base) {
  * @param {Array} fullforms - Custom full forms
  * @param {string} output - Output format
  * @param {string} spacer - Spacer character
+ * @param {boolean} pad - Whether to pad decimal places
+ * @param {number} round - Number of decimal places for padding
  * @param {string} [symbol] - Symbol to use (defaults based on bits/standard)
  * @returns {string|Array|Object|number} Formatted result
  */
@@ -74,11 +76,15 @@ export function handleZeroValue(
 	fullforms,
 	output,
 	spacer,
+	pad,
+	round,
 	symbol,
 ) {
 	let value;
 	if (precision > 0) {
 		value = (0).toPrecision(precision);
+	} else if (pad && round > 0) {
+		value = (0).toFixed(round);
 	} else {
 		value = 0;
 	}

--- a/tests/unit/filesize-helpers.test.js
+++ b/tests/unit/filesize-helpers.test.js
@@ -261,22 +261,70 @@ describe("Helper Functions", () => {
 
 describe("handleZeroValue with explicit symbol", () => {
 	it("should use provided symbol for string output", () => {
-		const result = handleZeroValue(0, "jedec", false, {}, false, [], "string", " ", "CustomB");
+		const result = handleZeroValue(
+			0,
+			"jedec",
+			false,
+			{},
+			false,
+			[],
+			"string",
+			" ",
+			false,
+			2,
+			"CustomB",
+		);
 		assert.strictEqual(result, "0 CustomB");
 	});
 
 	it("should use provided symbol for array output", () => {
-		const result = handleZeroValue(0, "jedec", false, {}, false, [], "array", " ", "CustomB");
+		const result = handleZeroValue(
+			0,
+			"jedec",
+			false,
+			{},
+			false,
+			[],
+			"array",
+			" ",
+			false,
+			2,
+			"CustomB",
+		);
 		assert.deepStrictEqual(result, [0, "CustomB"]);
 	});
 
 	it("should use provided symbol for object output", () => {
-		const result = handleZeroValue(0, "jedec", false, {}, false, [], "object", " ", "CustomB");
+		const result = handleZeroValue(
+			0,
+			"jedec",
+			false,
+			{},
+			false,
+			[],
+			"object",
+			" ",
+			false,
+			2,
+			"CustomB",
+		);
 		assert.deepStrictEqual(result, { value: 0, symbol: "CustomB", exponent: 0, unit: "CustomB" });
 	});
 
 	it("should use provided symbol for exponent output", () => {
-		const result = handleZeroValue(0, "jedec", false, {}, false, [], "exponent", " ", "CustomB");
+		const result = handleZeroValue(
+			0,
+			"jedec",
+			false,
+			{},
+			false,
+			[],
+			"exponent",
+			" ",
+			false,
+			2,
+			"CustomB",
+		);
 		assert.strictEqual(result, 0);
 	});
 });

--- a/tests/unit/filesize.test.js
+++ b/tests/unit/filesize.test.js
@@ -60,6 +60,16 @@ describe("filesize", () => {
 			assert.strictEqual(filesize(0, { output: "exponent" }), 0);
 		});
 
+		it("should pad zero like any other value", () => {
+			assert.strictEqual(filesize(0, { pad: true, round: 2 }), "0.00 B");
+			assert.strictEqual(filesize(0, { pad: true, round: 3 }), "0.000 B");
+			assert.strictEqual(filesize(0, { pad: true, round: 0 }), "0 B");
+		});
+
+		it("should prefer precision over pad for zero", () => {
+			assert.strictEqual(filesize(0, { precision: 3, pad: true, round: 5 }), "0.00 B");
+		});
+
 		it("should handle zero with custom symbols", () => {
 			assert.strictEqual(filesize(0, { symbols: { B: "Bytes" } }), "0 Bytes");
 		});


### PR DESCRIPTION
`handleZeroValue` never received `pad` or `round`, so padding was silently dropped for an input of exactly `0` while every nearby value padded:

```js
filesize(0,   {pad: true, round: 2}) // '0 B'     ← pad ignored
filesize(0.4, {pad: true, round: 2}) // '0.00 B'
filesize(1,   {pad: true, round: 2}) // '1.00 B'
```

Zero already honors `precision` (`filesize(0, {precision: 3})` → `'0.00 B'`), so dropping `pad` looks like an oversight rather than policy — and it makes fixed-width/tabular output misalign exactly at zero.

This passes `pad` and `round` through to the zero path and applies `toFixed(round)`, keeping `precision`'s precedence when both are set. Adds tests for padded zero, `round: 0`, and the precision-precedence case.