### PR TITLE
fix: keep plural fullform name with a comma decimal separator

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -410,6 +410,16 @@ export function decorateResult(
 		result[1] = symbols[result[1]];
 	}
 
+	// Capture the numeric value before formatting; a comma decimal separator
+	// (via separator or a locale such as de-DE) would otherwise make parseFloat
+	// read "1,5" as 1 and select the singular unit name.
+	let numericValue;
+	if (typeof result[0] === "string") {
+		numericValue = parseFloat(result[0]);
+	} else {
+		numericValue = result[0];
+	}
+
 	result[0] = applyNumberFormatting(
 		result[0],
 		locale,
@@ -427,15 +437,9 @@ export function decorateResult(
 		} else {
 			unit = BYTE;
 		}
-		let val;
-		if (typeof result[0] === "string") {
-			val = parseFloat(result[0]);
-		} else {
-			val = result[0];
-		}
 		// Determine singular/plural suffix
 		let suffix;
-		if (val === 1) {
+		if (numericValue === 1) {
 			suffix = EMPTY;
 		} else {
 			suffix = S;

--- a/tests/unit/filesize.test.js
+++ b/tests/unit/filesize.test.js
@@ -283,6 +283,11 @@ describe("filesize", () => {
 			);
 			assert.strictEqual(filesize(1234567890, { precision: 2, fullform: true }), "1.2 gigabytes");
 		});
+
+		it("should keep the plural fullform when a comma decimal separator is used", () => {
+			assert.strictEqual(filesize(1500000, { fullform: true, separator: "," }), "1,5 megabytes");
+			assert.strictEqual(filesize(1500000, { fullform: true, locale: "de-DE" }), "1,5 megabytes");
+		});
 	});
 
 	describe("Base and exponent options", () => {


### PR DESCRIPTION
### Bug

`fullform` picks the singular unit name for values it should pluralize whenever a comma is the decimal separator.

```js
filesize(1500000, { fullform: true })                  // "1.5 megabytes"  (correct)
filesize(1500000, { fullform: true, separator: "," })  // "1,5 megabyte"   (wrong)
filesize(1500000, { fullform: true, locale: "de-DE" }) // "1,5 megabyte"   (wrong)
```

Any value in `[1, 2)` is affected, and those are extremely common ("1,2 GB", "1,5 MB").

### Cause

`decorateResult` decides the singular/plural suffix by running `parseFloat` over the value *after* it has already been formatted into a string. `parseFloat("1,5")` stops at the comma and returns `1`, so the `val === 1` check treats 1.5 as exactly one and drops the plural `s`. Pluralization must depend on the magnitude, not on how the number is rendered.

### Fix

Capture the numeric value before locale/separator formatting turns it into a string, and use that value for the plural decision. The precision string path (`"1.2"`, period) still parses correctly, so existing behavior is unchanged.

Adds a regression test.
