### PR TITLE
fix: keep precision trailing zeros for negative values

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -403,7 +403,10 @@ export function decorateResult(
 	roundingFunc,
 ) {
 	if (neg) {
-		result[0] = -result[0];
+		// `precision` leaves the value as a string from toPrecision (e.g. "1.50").
+		// Negating that arithmetically coerces it back to a number and drops the
+		// trailing zeros the option asked for, so prefix the sign instead.
+		result[0] = typeof result[0] === "string" ? `-${result[0]}` : -result[0];
 	}
 
 	if (symbols[result[1]]) {

--- a/tests/unit/filesize.test.js
+++ b/tests/unit/filesize.test.js
@@ -394,6 +394,16 @@ describe("filesize", () => {
 			assert.strictEqual(filesize(-1234567890, { precision: 2 }), "-1.2 GB");
 		});
 
+		it("should keep precision trailing zeros for negative values", () => {
+			// A negative value must carry the same significant digits as its positive counterpart
+			assert.strictEqual(filesize(1500, { precision: 3 }), "1.50 kB");
+			assert.strictEqual(filesize(-1500, { precision: 3 }), "-1.50 kB");
+			assert.strictEqual(filesize(-1000, { precision: 3 }), "-1.00 kB");
+			assert.strictEqual(filesize(-1, { precision: 3 }), "-1.00 B");
+			assert.deepStrictEqual(filesize(-1500, { precision: 3, output: "array" }), ["-1.50", "kB"]);
+			assert.strictEqual(filesize(-1500, { precision: 3, output: "object" }).value, "-1.50");
+		});
+
 		it("should ensure no scientific notation in any precision result", () => {
 			// Test a range of numbers that would normally produce scientific notation from toPrecision
 			// but should have it removed by our implementation


### PR DESCRIPTION
The `precision` option leaves the value as a string from `toPrecision` (e.g. `"1.50"`), but `decorateResult` negated it arithmetically — coercing it back to a number and dropping the trailing zeros the option asked for:

```js
filesize(1500,  {precision: 3}) // '1.50 kB'
filesize(-1500, {precision: 3}) // '-1.5 kB'   <- precision lost
filesize(-1000, {precision: 3}) // '-1 kB'     <- expected '-1.00 kB'
```

So a negative value silently renders with fewer significant digits than its positive counterpart, and the same loss shows up in `array`/`object` output.

This prefixes the sign for the string case instead of negating it, so negatives keep the same digits as positives. Existing behavior is unchanged everywhere else — the number path still negates as before, and the existing `filesize(-1234567890, {precision: 2}) === '-1.2 GB'` assertion still passes.

Adds a regression test covering string, array and object output. Full suite green (200 passing).